### PR TITLE
Split api & Impl for all `GetSearchUseCase`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,6 +84,7 @@ dependencies {
     implementation(projects.core.ui)
     implementation(projects.core.designsystem)
     implementation(projects.core.data)
+    implementation(projects.core.domain.di)
     implementation(projects.core.model)
     implementation(projects.core.analytics)
     implementation(projects.sync.work)

--- a/core/domain/api/src/main/AndroidManifest.xml
+++ b/core/domain/api/src/main/AndroidManifest.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright 2022 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<manifest />

--- a/core/domain/api/src/main/kotlin/com/google/samples/apps/nowinandroid/core/domain/GetSearchContentsUseCase.kt
+++ b/core/domain/api/src/main/kotlin/com/google/samples/apps/nowinandroid/core/domain/GetSearchContentsUseCase.kt
@@ -16,16 +16,14 @@
 
 package com.google.samples.apps.nowinandroid.core.domain
 
-import dagger.Binds
-import dagger.Module
-import dagger.hilt.InstallIn
-import dagger.hilt.components.SingletonComponent
+import com.google.samples.apps.nowinandroid.core.model.data.UserSearchResult
+import kotlinx.coroutines.flow.Flow
 
-@InstallIn(SingletonComponent::class)
-@Module
-interface DomainModule {
-    @Binds
-    fun bindGetSearchContentsUseCase(
-        impl: DefaultGetSearchContentsUseCase,
-    ): GetSearchContentsUseCase
+/**
+ * A use case which returns the searched contents matched with the search query.
+ */
+interface GetSearchContentsUseCase {
+    operator fun invoke(
+        searchQuery: String,
+    ): Flow<UserSearchResult>
 }

--- a/core/domain/build.gradle.kts
+++ b/core/domain/build.gradle.kts
@@ -26,6 +26,7 @@ android {
 dependencies {
     api(projects.core.data)
     api(projects.core.model)
+    api(projects.core.domain.api)
 
     implementation(libs.javax.inject)
 

--- a/core/domain/src/main/kotlin/com/google/samples/apps/nowinandroid/core/domain/DefaultGetSearchContentsUseCase.kt
+++ b/core/domain/src/main/kotlin/com/google/samples/apps/nowinandroid/core/domain/DefaultGetSearchContentsUseCase.kt
@@ -27,15 +27,12 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import javax.inject.Inject
 
-/**
- * A use case which returns the searched contents matched with the search query.
- */
-class GetSearchContentsUseCase @Inject constructor(
+class DefaultGetSearchContentsUseCase @Inject constructor(
     private val searchContentsRepository: SearchContentsRepository,
     private val userDataRepository: UserDataRepository,
-) {
+) : GetSearchContentsUseCase {
 
-    operator fun invoke(
+    override operator fun invoke(
         searchQuery: String,
     ): Flow<UserSearchResult> =
         searchContentsRepository.searchContents(searchQuery)


### PR DESCRIPTION
Move `GetSearchUseCase` to `:core:domain:api` and then `DefaultGetSearchUseCase` to `:core:domain:impl`
